### PR TITLE
Feature: Update Xamarin.Google.Android.Play.Core package

### DIFF
--- a/Plugin.Maui.AppRating/Platforms/Android/AppRating.android.cs
+++ b/Plugin.Maui.AppRating/Platforms/Android/AppRating.android.cs
@@ -4,12 +4,10 @@ using Android.Content.PM;
 using Android.OS;
 using Xamarin.Google.Android.Play.Core.Review;
 using Xamarin.Google.Android.Play.Core.Review.Testing;
-using Xamarin.Google.Android.Play.Core.Tasks;
-using Task = System.Threading.Tasks.Task;
 
 namespace Plugin.Maui.AppRating;
 
-partial class AppRatingImplementation : Java.Lang.Object, IAppRating, IOnCompleteListener
+partial class AppRatingImplementation : Java.Lang.Object, IAppRating, Android.Gms.Tasks.IOnCompleteListener
 {
     private static volatile Handler? _handler;
 
@@ -17,7 +15,7 @@ partial class AppRatingImplementation : Java.Lang.Object, IAppRating, IOnComplet
 
     private IReviewManager? _reviewManager;
 
-    private Xamarin.Google.Android.Play.Core.Tasks.Task? _launchTask;
+    private Android.Gms.Tasks.Task? _launchTask;
 
     private bool _forceReturn;
 
@@ -116,7 +114,7 @@ partial class AppRatingImplementation : Java.Lang.Object, IAppRating, IOnComplet
         return tcs.Task;
     }
 
-    public void OnComplete(Xamarin.Google.Android.Play.Core.Tasks.Task task)
+    public void OnComplete(Android.Gms.Tasks.Task task)
     {
         if (!task.IsSuccessful || _forceReturn)
         {

--- a/Plugin.Maui.AppRating/Plugin.Maui.AppRating.csproj
+++ b/Plugin.Maui.AppRating/Plugin.Maui.AppRating.csproj
@@ -50,7 +50,7 @@
     </ItemGroup>
 
     <ItemGroup Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'android'">
-        <PackageReference Include="Xamarin.Google.Android.Play.Core" Version="1.10.3.11" />
+        <PackageReference Include="Xamarin.Google.Android.Play.Review.Ktx" Version="2.0.2.1" />
     </ItemGroup>
 
     <ItemGroup>


### PR DESCRIPTION
- [x] Replaced the old `Xamarin.Google.Android.Play.Core` package with the modern `Xamarin.Google.Android.Play.Review.Ktx` package that also supports .Net9
- [x] Fixes #11 